### PR TITLE
Add requestEthToAddr method to Session

### DIFF
--- a/src/lib/Session.js
+++ b/src/lib/Session.js
@@ -139,6 +139,10 @@ class Session {
   }
 
   requestEth(value, message) {
+    this.requestEthToAddr(this.config.paymentAddress, value, message);
+  }
+
+  requestEthToAddr(address, value, message) {
     if (!this.user.token_id) {
       Logger.error("Cannot send transactions to users with no payment address");
       return;
@@ -147,10 +151,10 @@ class Session {
     this.reply(SOFA.PaymentRequest({
       body: message,
       value: value,
-      destinationAddress: this.config.paymentAddress
+      destinationAddress: address
     }));
   }
-
+  
   load(onReady) {
     this.storage.loadBotSession(this.address).then((data) => {
       this.data = data;


### PR DESCRIPTION
Hey! This method allows the bot to request a payment to a different address than the one in the config file. It can be useful to request on behalf of a different user or send to a contract.